### PR TITLE
Allow an odd number of columns in the playing grid.

### DIFF
--- a/plugin/robots.vim
+++ b/plugin/robots.vim
@@ -9,7 +9,7 @@ function! s:InitAndStartRobots()   "{{{1
     let g:robots_player = '●'
 
     tabnew
-    let s:cols = 2*((getwininfo(win_getid())[0]['width']+5)/6)
+    let s:cols = (getwininfo(win_getid())[0]['width']+2)/3
     let s:rows = 2*(getwininfo(win_getid())[0]['height']/2) - 2
 
     setlocal filetype=robotsgame buftype=nofile bufhidden=wipe
@@ -75,7 +75,7 @@ function! s:DrawGrid()   "{{{1
     setlocal modifiable
     normal! ggdG
     for r in range(1,s:rows,1)
-        call append(0, strcharpart((r % 2 ? '' : '   ') . repeat('·     ', s:cols/2), 0, getwininfo(win_getid())[0]['width']))
+        call append(0, strcharpart((r % 2 ? '' : '   ') . repeat('·     ', s:cols), 0, getwininfo(win_getid())[0]['width']))
     endfor
     execute 'g/^$/d'
     call append(0, ['',''])


### PR DESCRIPTION
Closes #2.

The game was glitching because it thought 36 game grid columns (in a 103 column window) could fit in the window, when actually only 35 would. This could happen with other window widths as well. I fixed the calculation of `s:cols` so that an odd number of columns could be played, and the player or robots can no longer go past the right edge.